### PR TITLE
feat: add source & status in reservation member

### DIFF
--- a/sql/V1.001__Init.sql
+++ b/sql/V1.001__Init.sql
@@ -34,6 +34,17 @@ CREATE TYPE role_type AS ENUM (
     'NORMAL'
 );
 
+CREATE TYPE reservation_member_status AS ENUM (
+    'JOINED',
+    'INVITED',
+    'REJECTED'
+);
+
+CREATE TYPE reservation_member_source AS ENUM (
+    'SEARCH',
+    'INVITATION_CODE'
+);
+
 
 CREATE TABLE account
 (
@@ -162,7 +173,8 @@ CREATE TABLE reservation_member
     reservation_id INTEGER REFERENCES reservation (id) ,
     account_id     INTEGER REFERENCES account (id),
     is_manager     BOOLEAN DEFAULT FALSE,
-    is_joined      BOOLEAN DEFAULT FALSE,
+    status         reservation_member_status DEFAULT 'INVITED',
+    source         reservation_member_source DEFAULT 'INVITATION_CODE',
     PRIMARY KEY (reservation_id, account_id)
 );
 


### PR DESCRIPTION
### Added type
1. `reservation_member_status`: for recording status of reservation members,
    - `INVITED`: default value, member is invited but hasn't joined yet
    - `JOINED`: member had joined the reservation
    - `REJECTED`: member had been invited but reject the invitation.
2. `reservation_member_source`: for recording how member joined the reservation
    - `INVITATION`: default value, member is invited by manager.
    - `SEARCH`: member joined the reservation from search page.